### PR TITLE
Updated hook type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,9 @@
 ## Description
 
 First release of plugin with support for cordova 8.
+
+# 1.1.0
+
+## Description
+
+The hook types were modified. Now `hooks/after_plugins_install.js` runs _after\_plugin\_install_, _before\_start_ and _before\_compile_, instead of  _after\_plugin\_install_, _before\_start_ and _before\_prepare_.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-its-accountmanager",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Cordova plugin for Android Account Manager and iOS Keychain",
   "scripts": {},
   "repository": {

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
-  id="cordova-plugin-its-accountmanager" version="1.0.0">
+  id="cordova-plugin-its-accountmanager" version="1.1.0">
   <name>AccountManager</name>
   <description>Cordova plugin for Android Account Manager and iOS Keychain</description>
   <author>quentin.fung@hku.hk</author>

--- a/plugin.xml
+++ b/plugin.xml
@@ -44,7 +44,7 @@
     <resource-file src="src/android/res/drawable/am_icon.png" target="res/drawable/am_icon.png" />
 
     <hook type="after_plugin_install" src="hooks/after_plugin_install.js" />
-    <hook type="before_build" src="hooks/after_plugin_install.js" />
+    <hook type="before_compile" src="hooks/after_plugin_install.js" />
     <hook type="before_start" src="hooks/after_plugin_install.js" />
   </platform>
 


### PR DESCRIPTION
This change allows the `hooks/after_plugin_install.js` hook to detect the modified `config.xml` just after it is altered by another hook in the before_prepare phase.