### PR TITLE
adding "exported" attribute on plugin.xml

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -19,7 +19,7 @@
     </config-file>
 
     <config-file target="AndroidManifest.xml" parent="/manifest/application">
-      <service android:name="hk.hku.its.accountmanager.AuthenticatorService">
+      <service android:name="hk.hku.its.accountmanager.AuthenticatorService" android:exported="false">
         <intent-filter>
           <action android:name="android.accounts.AccountAuthenticator"/>
         </intent-filter>


### PR DESCRIPTION
Hi.

I created this PR to fix the following problem:

`android:exported needs to be explicitly specified for element <service#hk.hku.its.accountmanager.AuthenticatorService>. Apps targeting Android 12 and higher are required to specify an explicit value for `android:exported` when the corresponding component has an intent filter defined. See https://developer.android.com/guide/topics/manifest/activity-element#exported for details.`

Regards,
Daniel Arza.